### PR TITLE
Add balena & balenaHub support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Options:
 1. Load url [https://netstatus.ryanpowell.dev](https://netstatus.ryanpowell.dev) in Browser
 2. Build project & serve static files (Download project, run `npm run build` & serve contents from ./build)
 3. Deploy locally with Docker below & open http://localhost:80 
+4. [Deploy with balena](https://dashboard.balena-cloud.com/deploy?repoUrl=https://github.com/Ryandev/NetStatus) (more details below)
 
 ### Docker Deployment
 Run below (supports amd64, arm64 & arv7, aka PC, Pi4, Pi3)
@@ -63,6 +64,17 @@ Set speed test interval to 10mins, ping checks every 1min, & latency warn thresh
 ```
 sudo docker run --name netspeed -d --restart=always -p 80:80 --env REACT_APP_TESTINTERVAL=600 --env REACT_APP_PINGINTERVAL=60 --env REACT_APP_LATENCYWARN=20 ryandev/netspeed:arm64
 ```
+
+#### Balena Deployment Example
+You can use balenaCloud to deploy this project to Raspberry Pis and other single board computers in just a few clicks, avoiding the need to manually configure any software packages.
+
+[![](https://balena.io/deploy.svg)](https://dashboard.balena-cloud.com/deploy?repoUrl=https://github.com/Ryandev/NetStatus)
+
+**or, manually:**
+
+* Install the [balena CLI tools](https://github.com/balena-io/balena-cli/blob/master/INSTALL.md)
+* Login with `balena login`
+* Download this project and from the project directory run `balena push <appName>` where `<appName>` is the name you gave your balenaCloud application in the first step
 
 
 ### Attributions

--- a/balena.yml
+++ b/balena.yml
@@ -1,0 +1,22 @@
+name: "NetStatus"
+description: "Internet speed & offline status monitor. Upload, download, ping, latency dashboard display"
+type: "sw.application"
+assets:
+  repository:
+    type: "blob.asset"
+    data:
+      url: "https://github.com/Ryandev/NetStatus"
+  logo:
+    type: "blob.asset"
+    data:
+      url: "https://raw.githubusercontent.com/Ryandev/NetStatus/master/public/logo512.png"
+data:  
+  defaultDeviceType: "raspberrypi3"
+  supportedDeviceTypes:
+    - "raspberrypi4-64"
+    - "fincm3"
+    - "raspberrypi3"
+    - "raspberrypi3-64"
+    - "intel-nuc"
+    - "genericx86-64-ext"
+    - "raspberrypi400-64"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+services:
+  netspeed:
+    image: ryandev/netspeed
+    ports:
+      - "80"
+    restart: always
+  browser:
+    image: balenablocks/browser
+    network_mode: host
+    privileged: true
+    environment:
+        - 'KIOSK=1'
+  fbcp:
+    image: balenablocks/fbcp
+    privileged: true


### PR DESCRIPTION
Hey there - cool project! I work at balena and wanted to try your container to see if it runs, which it does, beautifully. So, I added a docker-compose file and balena config that allows the app to be pushed to a balena device without requiring any further configuration - it includes a container with a browser to show the output on a screen and an FBCP container for running the small TFTs. This makes it possible to get up and running in a few minutes - zero command line stuff needed! I've tested this setup on a Pi3 and a Pi4.

In addition to powering the deploy button, the balena.yml and logo will also allow the project to be listed on https://hub.balena.io :)